### PR TITLE
Fix crash with level 4-4 gamesave

### DIFF
--- a/returbot/levels/custom/rb04/level004/Control.txt
+++ b/returbot/levels/custom/rb04/level004/Control.txt
@@ -3,8 +3,10 @@ public class Camps
     static point[] camps, resp0, resp1, resp2, resp3, resp4;
     static float[] awd = {40, 40, 40, 40, 40};
     static float[] out0 = {1,1}, out1 = {1,1}, out2 = {1,1}, out3 = {1,1}, out4 = {1,1};
-    static int lim0 = 12, lim1 = 12, lim2 = 9, lim3 = 12, lim4 = 9;
+    private static int[] lim = { 12, 12, 9, 12, 9 };
     
+    float GetLim(int i) { return lim[i]; }
+
     void Camps()
     {
         if(camps == null)
@@ -246,11 +248,11 @@ extern void LvlCntlr_main()
         {
             if(i >= sizeof(camps.awd) or camps.awd[i] < 0)
             {
-                if(i == 0){ out = camps.out0; lim = camps.lim0; }
-                if(i == 1){ out = camps.out1; lim = camps.lim1; }
-                if(i == 2){ out = camps.out2; lim = camps.lim2; }
-                if(i == 3){ out = camps.out3; lim = camps.lim3; }
-                if(i == 4){ out = camps.out4; lim = camps.lim4; }
+                if(i == 0){ out = camps.out0; lim = camps.GetLim(0); }
+                if(i == 1){ out = camps.out1; lim = camps.GetLim(1); }
+                if(i == 2){ out = camps.out2; lim = camps.GetLim(2); }
+                if(i == 3){ out = camps.out3; lim = camps.GetLim(3); }
+                if(i == 4){ out = camps.out4; lim = camps.GetLim(4); }
                 if(i > 4){ break; }
                 i2 = 0;
                 while(lim > 0 and i2 < sizeof(out))

--- a/returbot/levels/custom/rb04/level004/Control.txt
+++ b/returbot/levels/custom/rb04/level004/Control.txt
@@ -4,29 +4,33 @@ public class Camps
     static float[] awd = {40, 40, 40, 40, 40};
     static float[] out0 = {1,1}, out1 = {1,1}, out2 = {1,1}, out3 = {1,1}, out4 = {1,1};
     private static int[] lim = { 12, 12, 9, 12, 9 };
-    
+
+    // Constructor
+    void Camps() {}
+
     float GetLim(int i) { return lim[i]; }
 
-    void Camps()
+    // Initialize static data, called only once in LvlCntlr_main()
+    void InitCamps()
     {
         if(camps == null)
         {
-            camps[0].x = -160.09; camps[0].y = 9.69802; camps[0].z = 0;
-            camps[1].x = -169.342; camps[1].y = 90.0963; camps[1].z = 0;
-            camps[2].x = -138.376; camps[2].y = 141.723; camps[2].z = 0;
-            camps[3].x = -8.62029; camps[3].y = 178.623; camps[3].z = 0;
-            camps[4].x = 30.2652; camps[4].y = 50.2889; camps[4].z = 0;
-            resp0[0].x = -350.602; resp0[0].y = 84.2715; resp0[0].z = 0;
-            resp0[1].x = -345.931; resp0[1].y = -84.621; resp0[1].z = 0;
-            resp1[0].x = -321.713; resp1[0].y = 144.735; resp1[0].z = 0;
-            resp1[1].x = -333.848; resp1[1].y = 141.365; resp1[1].z = 0;
-            resp2[0].x = -181.894; resp2[0].y = 156.12; resp2[0].z = 0;
-            resp2[1].x = -181.621; resp2[1].y = 165.214; resp2[1].z = 0;
-            resp3[0].x = 202.222; resp3[0].y = 244.837; resp3[0].z = 0;
-            resp3[1].x = 107.624; resp3[1].y = 356.806; resp3[1].z = 0;
-            resp3[2].x = -2.72068; resp3[2].y = 351.422; resp3[2].z = 0;
-            resp4[0].x = 195.726; resp4[0].y = 354.882; resp4[0].z = 0;
-            resp4[1].x = 202.471; resp4[1].y = 232.146; resp4[1].z = 0;
+            camps[0] = new point(-160.09, 9.69802, 0);
+            camps[1] = new point(-169.342, 90.0963, 0);
+            camps[2] = new point(-138.376, 141.723, 0);
+            camps[3] = new point(-8.62029, 178.623, 0);
+            camps[4] = new point(30.2652, 50.2889, 0);
+            resp0[0] = new point(-350.602, 84.2715, 0);
+            resp0[1] = new point(-345.931, -84.621, 0);
+            resp1[0] = new point(-321.713, 144.735, 0);
+            resp1[1] = new point(-333.848, 141.365, 0);
+            resp2[0] = new point(-181.894, 156.12, 0);
+            resp2[1] = new point(-181.621, 165.214, 0);
+            resp3[0] = new point(202.222, 244.837, 0);
+            resp3[1] = new point(107.624, 356.806, 0);
+            resp3[2] = new point(-2.72068, 351.422, 0);
+            resp4[0] = new point(195.726, 354.882, 0);
+            resp4[1] = new point(202.471, 232.146, 0);
         }
     }
 }
@@ -180,6 +184,7 @@ extern void LvlCntlr_main()
     float out[];
     
     Camps camps();
+    camps.InitCamps();
     
     i = 0;
 	list[i++] = AlienEgg;


### PR DESCRIPTION
@rbcat 

Fixed crash described in [Issue #1 comment](https://github.com/rbcat/returbot/issues/1#issuecomment-366796742).

Note:
Changing script code is usually incompatible with previous saved games, causing crashes and other errors.